### PR TITLE
Fix python3 installation for linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ sudo apt install python3
 ```
 3. Install Python3 For Arch Linux:
 ```
-sudo pacman -S install python
+sudo pacman -S python
 ```
 3. Install Python3 For Fedora:
 ```


### PR DESCRIPTION
It's not `sudo pacman -S install python`, but rather `sudo pacman -S python`