### PR TITLE
In Manjaro, Lutris may fail due to python-evdev

### DIFF
--- a/LibreGaming/LibreGaming.py
+++ b/LibreGaming/LibreGaming.py
@@ -148,7 +148,7 @@ def Lutris():
             os.system(i) #running each element in Ubuntu array 
     elif PackageManager == distro[1] or PackageManager == distro[2] or PackageManager == distro[3]:    
         print("\ninstalling Lutris for Arch")
-        Arch = rootCommand + " pacman -S lutris -y --needed --noconfirm"
+        Arch = rootCommand + " pacman -S python-evdev lutris -y --needed --noconfirm"
         os.system(Arch)
     elif PackageManager == distro[4]:    #packages for Fedora
         print("\ninstalling Lutris for Fedora")


### PR DESCRIPTION
In some cases, you need to also install python-evdev when installing lutris. If python-evdev is not installed, you may end up having this error:

Warning: python-evdev: /usr/lib/python3.10/site-packages/evdev-1.4.0-py3.10.egg-info already exists in filesystem

and several other errors.

This patch only adds evdev to the list of packages being installed when installing Lutrtis. It wont do anything if the user has it already installed.